### PR TITLE
Make inline comments stay inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,21 +35,5 @@ hello = 'hello'
 ```
 More examples can be found in test_parse.py and test_unparse.py.
 
-## Notes
-1. Right now it is assumed that there is no difference between inlined comments and regular. 
-All inlined comments become regular after the tree object is unparsed.
-
-2. Inlined comments for class- (def-, if-, ...) block shift "inside" body of the corresponding block:
-    ```
-    >>> source = """class Foo: # c1
-    ...     pass
-    ... """
-    >>> unparse(parse(source))
-    >>> print(unparse(parse(source)))
-    class Foo:
-        # c1
-        pass
-    ```
-
 ## Contributing
 You are welcome to open an issue or create a pull request

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+
+setup(name="ast-comments")

--- a/test_unparse.py
+++ b/test_unparse.py
@@ -171,3 +171,28 @@ def test_comment_to_multiline_expr():
         """
     )
     _test_unparse(source)
+
+
+def test_inline_comments_stay_inline():
+    source = dedent(
+        """
+        class Foo:  # c1
+            pass
+        """
+    )
+    _test_unparse(source)
+    unparsed_source = unparse(parse(source))
+    assert "class Foo:  # c1" in unparsed_source
+
+
+def test_comments_in_body():
+    source = dedent(
+        """
+        class Foo: 
+            # c1
+            pass
+        """
+    )
+    _test_unparse(source)
+    unparsed_source = unparse(parse(source))
+    assert "class Foo:\n    # c1" in unparsed_source


### PR DESCRIPTION
First of all, thanks for this project. I use it in my project for detecting ignore comments :D

This is my approach for making inline comments stay inline.
I overwrote the traverse to inspect the first item of the body (maybe a comment) and save the lineno to a list if the lines of body parent and comment match. 
When visiting a comment I immediately write the comment with two leading spaces instead of writing a newline by using fill.


When adding a setup.py with your package name you can see which packages depend on yours on github. Just a litte bonus :)