### PR TITLE
make inline comments stay inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The only difference is there is a new type of tree node: Comment
 >>> tree.body[0].value
 '# comment to hello'
 >>> dump(tree)
-"Module(body=[Comment(value='# comment to hello'), Assign(targets=[Name(id='hello', ctx=Store())], value=Constant(value='hello', kind=None), type_comment=None)], type_ignores=[])"
+"Module(body=[Assign(targets=[Name(id='hello', ctx=Store())], value=Constant(value='hello', kind=None), type_comment=None), Comment(value='# comment to hello', inline=True)], type_ignores=[])"
 ```
 If you have python3.9 or above it's also possible to unparse the tree object with its comments preserved.
 ```
@@ -34,22 +34,6 @@ If you have python3.9 or above it's also possible to unparse the tree object wit
 hello = 'hello'
 ```
 More examples can be found in test_parse.py and test_unparse.py.
-
-## Notes
-1. Right now it is assumed that there is no difference between inlined comments and regular. 
-All inlined comments become regular after the tree object is unparsed.
-
-2. Inlined comments for class- (def-, if-, ...) block shift "inside" body of the corresponding block:
-    ```
-    >>> source = """class Foo: # c1
-    ...     pass
-    ... """
-    >>> unparse(parse(source))
-    >>> print(unparse(parse(source)))
-    class Foo:
-        # c1
-        pass
-    ```
 
 ## Contributing
 You are welcome to open an issue or create a pull request

--- a/test_unparse.py
+++ b/test_unparse.py
@@ -93,7 +93,7 @@ def test_comment_to_class():
         """
         # comment to class 'Foo'
         class Foo:
-            var = "Foo var"    # comment to 'Foo.var'
+            var = "Foo var"  # comment to 'Foo.var'
 
             # comment to method 'foo'
             def foo(self):
@@ -134,10 +134,10 @@ def test_comments_to_for():
     """Comments to for/else blocks."""
     source = dedent(
         """
-        for i in range(10): # for comment
-            continue    # continue comment
-        else:   # else comment
-            pass    # pass comment
+        for i in range(10):  # for comment
+            continue  # continue comment
+        else:  # else comment
+            pass  # pass comment
         """
     )
     _test_unparse(source)
@@ -147,16 +147,16 @@ def test_comments_to_try():
     """Comments to try/except/else/finally blocks."""
     source = dedent(
         """
-        try:    # try comment
-            1 / 0   # expr comment
+        try:  # try comment
+            1 / 0  # expr comment
         except ValueError:  # except ValueError comment
-            pass    # pass comment
-        except KeyError:    # except KeyError
-            pass    # pass comment
-        else:   # else comment
-            print() # print comment
-        finally:    # finally comment
-            print() # print comment
+            pass  # pass comment
+        except KeyError:  # except KeyError
+            pass  # pass comment
+        else:  # else comment
+            print()  # print comment
+        finally:  # finally comment
+            print()  # print comment
         """
     )
     _test_unparse(source)
@@ -193,3 +193,23 @@ def test_nested_ifs_to_elifs():
     assert r.count("if") == 2  # if and elif
     assert r.count("elif") == 1
     assert r.count("else") == 1
+
+
+def test_inline_comment_stays_inline():
+    source = dedent(
+        """ 
+    # abc
+
+    class Foo:
+        pass
+        
+    class Bar:  # def
+        pass
+        
+    class FooBar:
+        # ghi
+        pass
+    """
+    )
+    _test_unparse(source)
+    assert source.strip("\n") == unparse(parse(source))


### PR DESCRIPTION
2nd attempt inspired by your idea in #9

- comment nodes are now positioned after and not before the nodes in the same line
