### PR TITLE
Fixed taking the correct interval and placing them into the correct position

### DIFF
--- a/ast_comments.py
+++ b/ast_comments.py
@@ -164,7 +164,7 @@ def _extend_interval(
         else:
             break
 
-    while high + 1 < len(lines) - 1:
+    while high + 1 < len(lines):
         if start_indentation <= _get_indentation_lvl(lines[high + 1]):
             high += 1
         else:

--- a/ast_comments.py
+++ b/ast_comments.py
@@ -125,7 +125,8 @@ def _get_tree_intervals_and_update_ast_nodes(
                 node.end_col_offset = len(source.split('\n')[high - 1])
             else:
                 low = min(node.lineno, min(attr_intervals)[0]) if hasattr(node, "lineno") else min(attr_intervals)[0]
-                high = max(node.end_lineno, max(attr_intervals)[1]) if hasattr(node, "end_lineno") else max(attr_intervals)[1]
+                high = max(node.end_lineno, max(attr_intervals)[1]) if hasattr(node, "end_lineno") else \
+                    max(attr_intervals)[1]
 
             res[(low, high)] = {"intervals": attr_intervals, "node": node}
     return res
@@ -137,7 +138,7 @@ def _get_tree_intervals_and_update_ast_nodes(
 def _extend_interval(
         interval: Tuple[int, int],
         code: str
-) -> tuple[int, int]:
+) -> Tuple[int, int]:
     lines = code.split('\n')
     # Insert an empty line to correspond to the lineno values from ast nodes which start at 1 instead of 0
     lines.insert(0, '')
@@ -170,7 +171,7 @@ def _extend_interval(
         else:
             break
 
-    return (low, high)
+    return low, high
 
 
 # Searches for the first line not being a comment
@@ -238,6 +239,7 @@ if sys.version_info >= (3, 9):
                 self.fill("else")
                 with self.block():
                     self.traverse(node.orelse)
+
 
     def unparse(ast_obj: ast.AST) -> str:
         return _Unparser().visit(ast_obj)

--- a/ast_comments.py
+++ b/ast_comments.py
@@ -113,12 +113,12 @@ def _get_tree_intervals_and_update_ast_nodes(
             if items := getattr(node, attr, None):
                 if not isinstance(items, Iterable):
                     continue
-                attr_intervals.append(_post_extend_interval((*_get_interval(items), attr), source))
+                attr_intervals.append((*_extend_interval(_get_interval(items), source), attr))
         if attr_intervals:
             # If the parent node hast lineno and end_lineno we extend them too, because there could be comments at the
             #  end not covered by the intervals gathered in the attributes
             if hasattr(node, "lineno") and hasattr(node, "end_lineno"):
-                low, high, _ = _post_extend_interval((node.lineno, node.end_lineno, ''), source)
+                low, high = _extend_interval((node.lineno, node.end_lineno), source)
                 node.lineno = low
                 node.end_lineno = high
                 # also update the end col offset corresponding to the new line
@@ -131,13 +131,17 @@ def _get_tree_intervals_and_update_ast_nodes(
     return res
 
 
-### Try to move lower bound lower and upper bound higher while not going out of bounds concerning the current block
-def _post_extend_interval(
-        interval: Tuple[int, int, str],
+# Try to move lower bound lower and upper bound higher while not going out of bounds concerning the current block
+# The method is based on indentation levels to find the correct upper and lower bounds of the interval looked at
+# by checking where the indentation changes, and it marks the end of the interval
+def _extend_interval(
+        interval: Tuple[int, int],
         code: str
-) -> Union[List[Tuple[int, int]], ast.AST]:
+) -> tuple[int, int]:
     lines = code.split('\n')
+    # Insert an empty line to correspond to the lineno values from ast nodes which start at 1 instead of 0
     lines.insert(0, '')
+
     low = interval[0]
     high = interval[1]
     skip_lower = False
@@ -164,7 +168,7 @@ def _post_extend_interval(
         else:
             break
 
-    return (low, high, interval[2])
+    return (low, high)
 
 
 def _get_indentation_lvl(line: str) -> int:

--- a/ast_comments.py
+++ b/ast_comments.py
@@ -58,7 +58,7 @@ def _enrich(source: Union[str, bytes], tree: ast.AST) -> None:
         ]
 
         if possible_intervals_for_c_node:
-            target_interval = tree_intervals[max(possible_intervals_for_c_node)]
+            target_interval = tree_intervals[max(possible_intervals_for_c_node, key=lambda item: (item[0], -item[1]))]
 
             target_node = target_interval["node"]
             # intervals for every attribute from _CONTAINER_ATTRS for the target node

--- a/ast_comments.py
+++ b/ast_comments.py
@@ -121,6 +121,8 @@ def _get_tree_intervals_and_update_ast_nodes(
             high = max(node.end_lineno, max(attr_intervals)[1]) if hasattr(node, "end_lineno") else max(attr_intervals)[1]
             if hasattr(node, "end_lineno"):
                 node.end_lineno = high
+                # also update the end col offset corresponding to the new line
+                node.end_col_offset = len(source.split('\n')[high - 1])
 
             res[(low, high)] = {"intervals": attr_intervals, "node": node}
     return res

--- a/test_parse.py
+++ b/test_parse.py
@@ -9,7 +9,7 @@ from ast_comments import Comment, parse
 
 
 def test_comment_at_start_of_inner_block_getting_correctly_parsed():
-    """Parsed tree has Comment node."""
+    """Comment at the start of a new inlined block/interval"""
     source = dedent(
         """
         def test():
@@ -22,7 +22,7 @@ def test_comment_at_start_of_inner_block_getting_correctly_parsed():
 
 
 def test_comment_at_start_of_inner_block_with_wrong_indentation_is_still_inside_the_block():
-    """Parsed tree has Comment node."""
+    """Comment at the start of a new inlined block/interval with wrong indentation"""
     source = dedent(
         """
         def test():
@@ -35,7 +35,7 @@ def test_comment_at_start_of_inner_block_with_wrong_indentation_is_still_inside_
 
 
 def test_comment_at_end_of_inner_block_getting_correctly_parsed():
-    """Parsed tree has Comment node."""
+    """Comment at the end of a new inlined block/interval"""
     source = dedent(
         """
         def test():
@@ -48,7 +48,7 @@ def test_comment_at_end_of_inner_block_getting_correctly_parsed():
 
 
 def test_comment_at_end_of_inner_block_with_wrong_indentation_gets_moved_to_next_block():
-    """Parsed tree has Comment node."""
+    """Comment at the end of a new inlined block/interval with wrong indentation should get assigned to next block"""
     source = dedent(
         """
         if 1 == 1:

--- a/test_parse.py
+++ b/test_parse.py
@@ -15,16 +15,21 @@ def test_all_comments_in_tree():
 print('1')
 # Comment 2
 if 1 == 1:
-    # Comment 3
+# Comment 3
     print('2')
     # Comment 4
 else:
-    # Comment 5
+# Comment 5
     print('3')
     # Comment 6
 # Comment 7
 print('4')
 # Comment 8
+def test():
+# Comment 9
+    print('2')
+    # Comment 10
+# Comment 11
 """
     nodes = parse(source).body
     assert len(nodes) == 7

--- a/test_parse.py
+++ b/test_parse.py
@@ -8,33 +8,58 @@ import pytest
 from ast_comments import Comment, parse
 
 
-def test_all_comments_in_tree():
+def test_comment_at_start_of_inner_block_getting_correctly_parsed():
     """Parsed tree has Comment node."""
-    source = """
-# Comment 1
-print('1')
-# Comment 2
-if 1 == 1:
-# Comment 3
-    print('2')
-    # Comment 4
-else:
-# Comment 5
-    print('3')
-    # Comment 6
-# Comment 7
-print('4')
-# Comment 8
-def test():
-# Comment 9
-    print('2')
-    # Comment 10
-# Comment 11
-"""
+    source = dedent(
+        """
+        def test():
+            # Comment at start of block
+            hello = 'hello'
+        """
+    )
     nodes = parse(source).body
-    assert len(nodes) == 7
-    assert isinstance(nodes[0], Comment)
-    assert not nodes[0].inline
+    assert isinstance(nodes[0].body[0], Comment)
+
+
+def test_comment_at_start_of_inner_block_with_wrong_indentation_is_still_inside_the_block():
+    """Parsed tree has Comment node."""
+    source = dedent(
+        """
+        def test():
+        # Comment at start of block
+            hello = 'hello'
+        """
+    )
+    nodes = parse(source).body
+    assert isinstance(nodes[0].body[0], Comment)
+
+
+def test_comment_at_end_of_inner_block_getting_correctly_parsed():
+    """Parsed tree has Comment node."""
+    source = dedent(
+        """
+        def test():
+            hello = 'hello'
+            # Comment at end of block
+        """
+    )
+    nodes = parse(source).body
+    assert isinstance(nodes[0].body[1], Comment)
+
+
+def test_comment_at_end_of_inner_block_with_wrong_indentation_gets_moved_to_next_block():
+    """Parsed tree has Comment node."""
+    source = dedent(
+        """
+        if 1 == 1:
+            hello = 'hello'
+        # Comment at end of block
+        else:
+            hello = 'hello'
+        """
+    )
+    nodes = parse(source).body
+    assert isinstance(nodes[0].orelse[0], Comment)
 
 
 def test_single_comment_in_tree():

--- a/test_parse.py
+++ b/test_parse.py
@@ -8,7 +8,7 @@ import pytest
 from ast_comments import Comment, parse
 
 
-def test_all_comment_places_in_tree():
+def test_all_comments_in_tree():
     """Parsed tree has Comment node."""
     source = """
 # Comment 1

--- a/test_parse.py
+++ b/test_parse.py
@@ -8,6 +8,30 @@ import pytest
 from ast_comments import Comment, parse
 
 
+def test_all_comment_places_in_tree():
+    """Parsed tree has Comment node."""
+    source = """
+# Comment 1
+print('1')
+# Comment 2
+if 1 == 1:
+    # Comment 3
+    print('2')
+    # Comment 4
+else:
+    # Comment 5
+    print('3')
+    # Comment 6
+# Comment 7
+print('4')
+# Comment 8
+"""
+    nodes = parse(source).body
+    assert len(nodes) == 7
+    assert isinstance(nodes[0], Comment)
+    assert not nodes[0].inline
+
+
 def test_single_comment_in_tree():
     """Parsed tree has Comment node."""
     source = """# comment"""

--- a/test_unparse.py
+++ b/test_unparse.py
@@ -21,24 +21,54 @@ def _test_unparse(source: str):
     assert dump(source_tree) == dump(equivalent_tree)
 
 
-def test_all_comment_places_in_tree():
+
+def test_comment_at_start_of_inner_block_getting_correctly_parsed():
     """Parsed tree has Comment node."""
-    source = """
-# Comment 1
-print('1')
-# Comment 2
-if 1 == 1:
-    # Comment 3
-    print('2')
-    # Comment 4
-else:
-    # Comment 5
-    print('3')
-    # Comment 6
-# Comment 7
-print('4')
-# Comment 8
-"""
+    source = dedent(
+        """
+        def test():
+            # Comment at start of block
+            hello = 'hello'
+        """
+    )
+    _test_unparse(source)
+
+
+def test_comment_at_start_of_inner_block_with_wrong_indentation_is_still_inside_the_block():
+    """Parsed tree has Comment node."""
+    source = dedent(
+        """
+        def test():
+        # Comment at start of block
+            hello = 'hello'
+        """
+    )
+    _test_unparse(source)
+
+
+def test_comment_at_end_of_inner_block_getting_correctly_parsed():
+    """Parsed tree has Comment node."""
+    source = dedent(
+        """
+        def test():
+            hello = 'hello'
+            # Comment at end of block
+        """
+    )
+    _test_unparse(source)
+
+
+def test_comment_at_end_of_inner_block_with_wrong_indentation_gets_moved_to_next_block():
+    """Parsed tree has Comment node."""
+    source = dedent(
+        """
+        if 1 == 1:
+            hello = 'hello'
+        # Comment at end of block
+        else:
+            hello = 'hello'
+        """
+    )
     _test_unparse(source)
 
 

--- a/test_unparse.py
+++ b/test_unparse.py
@@ -21,9 +21,8 @@ def _test_unparse(source: str):
     assert dump(source_tree) == dump(equivalent_tree)
 
 
-
 def test_comment_at_start_of_inner_block_getting_correctly_parsed():
-    """Parsed tree has Comment node."""
+    """Comment at the start of a new inlined block/interval"""
     source = dedent(
         """
         def test():
@@ -35,7 +34,7 @@ def test_comment_at_start_of_inner_block_getting_correctly_parsed():
 
 
 def test_comment_at_start_of_inner_block_with_wrong_indentation_is_still_inside_the_block():
-    """Parsed tree has Comment node."""
+    """Comment at the start of a new inlined block/interval with wrong indentation"""
     source = dedent(
         """
         def test():
@@ -47,7 +46,7 @@ def test_comment_at_start_of_inner_block_with_wrong_indentation_is_still_inside_
 
 
 def test_comment_at_end_of_inner_block_getting_correctly_parsed():
-    """Parsed tree has Comment node."""
+    """Comment at the end of a new inlined block/interval"""
     source = dedent(
         """
         def test():
@@ -59,7 +58,7 @@ def test_comment_at_end_of_inner_block_getting_correctly_parsed():
 
 
 def test_comment_at_end_of_inner_block_with_wrong_indentation_gets_moved_to_next_block():
-    """Parsed tree has Comment node."""
+    """Comment at the end of a new inlined block/interval with wrong indentation should get assigned to next block"""
     source = dedent(
         """
         if 1 == 1:

--- a/test_unparse.py
+++ b/test_unparse.py
@@ -21,6 +21,27 @@ def _test_unparse(source: str):
     assert dump(source_tree) == dump(equivalent_tree)
 
 
+def test_all_comment_places_in_tree():
+    """Parsed tree has Comment node."""
+    source = """
+# Comment 1
+print('1')
+# Comment 2
+if 1 == 1:
+    # Comment 3
+    print('2')
+    # Comment 4
+else:
+    # Comment 5
+    print('3')
+    # Comment 6
+# Comment 7
+print('4')
+# Comment 8
+"""
+    _test_unparse(source)
+
+
 def test_single_comment_in_tree():
     source = """# comment"""
     _test_unparse(source)


### PR DESCRIPTION
The problem was with taking the max of the intervals, which were tuples of (x, y) values. We have to take the biggest starting interval, therefore biggest x, and then the smallest ending interval, meaning y. An example which did not work before and which put all comments in the beginning of the code after unparse is performed is:
`
if 1 == 1:
   #Test1
   print('a')
else:
   #Test2
   print('b')
print('b')
`
![image](https://github.com/t3rn0/ast-comments/assets/43956528/2455c1ae-a2a1-4298-9626-6fc4bfed40d2)
