### PR TITLE
make parse's output compilable - switch base class to ast.Pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ If you have python3.9 or above it's also possible to unparse the tree object wit
 >>> print(unparse(tree))
 hello = 'hello'  # comment to hello
 ```
+**Note**: Python `compile()` cannot be run on the tree output from parse. The included `pre_compile_fixer()` function can be used to fix the tree (stripping 
+comment nodes) if it will be necessary to compile the output.
+
 More examples can be found in test_parse.py and test_unparse.py.
 
 ## Contributing

--- a/ast_comments.py
+++ b/ast_comments.py
@@ -260,3 +260,16 @@ if sys.version_info >= (3, 9):
 
     def unparse(ast_obj: ast.AST) -> str:
         return _Unparser().visit(ast_obj)
+
+
+def pre_compile_fixer(tree: ast.AST) -> ast.AST:
+    """
+    The parse output from ast_comments cannot compile (see issue #23). This function can be
+    run to fix the output so that it can compile.  This transformer strips out Comment nodes.
+    """
+
+    class RewriteComments(ast.NodeTransformer):
+        def visit_Comment(self, node: ast.AST) -> ast.AST:
+            return None
+
+    return RewriteComments().visit(tree)


### PR DESCRIPTION
making the base class 'ast.Pass' allows the compiler to recognize that the nodes can be ignored during compilation

Also, update parse test to require clean compile run for every test scenario

Fixes issue #23 